### PR TITLE
Add Airbyte configs and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # CityScale-AI-Real-Time-CBD-Foot-Traffic-Forecasting-MLOps-Platform
+
+## Airbyte Connections
+
+Example source and destination configuration templates are available under `airbyte/config`.
+Each file contains placeholder credentials and incremental sync settings so that only new or
+updated records are transferred on each run.
+
+### Deploy with Docker Compose
+
+1. Replace the credential placeholders in the YAML files or provide the values as environment
+   variables before deployment.
+2. Start the Airbyte services using Docker Compose:
+
+   ```bash
+   docker compose up -d
+   ```
+3. Apply the configuration files via the Airbyte CLI or API. Example using the Airbyte CLI
+   container:
+
+   ```bash
+   docker compose run --rm airbyte-cli apply --config-dir airbyte/config
+   ```
+
+The above command will register the sources and Snowflake destination defined in the YAML files.

--- a/airbyte/config/event_source.yaml
+++ b/airbyte/config/event_source.yaml
@@ -1,0 +1,11 @@
+source:
+  name: city_events
+  connector: http
+  configuration:
+    base_url: https://api.events.example.com
+    api_key: ${EVENT_API_KEY}
+    start_date: "2023-01-01T00:00:00Z"
+    city: YOUR_CITY
+  incremental_sync:
+    cursor_field: updated_at
+    replication_method: incremental

--- a/airbyte/config/pedestrian_source.yaml
+++ b/airbyte/config/pedestrian_source.yaml
@@ -1,0 +1,10 @@
+source:
+  name: pedestrian_counts
+  connector: http
+  configuration:
+    base_url: https://api.example.com/pedestrian
+    api_key: ${PEDESTRIAN_API_KEY}
+    start_date: "2023-01-01T00:00:00Z"
+  incremental_sync:
+    cursor_field: timestamp
+    replication_method: incremental

--- a/airbyte/config/snowflake_destination.yaml
+++ b/airbyte/config/snowflake_destination.yaml
@@ -1,0 +1,14 @@
+destination:
+  name: warehouse
+  connector: snowflake
+  configuration:
+    account: ${SNOWFLAKE_ACCOUNT}
+    username: ${SNOWFLAKE_USER}
+    password: ${SNOWFLAKE_PASSWORD}
+    database: ${SNOWFLAKE_DATABASE}
+    schema: ${SNOWFLAKE_SCHEMA}
+    warehouse: ${SNOWFLAKE_WAREHOUSE}
+  incremental_sync:
+    destination_sync_mode: append_dedup
+    primary_key: id
+    cursor_field: timestamp

--- a/airbyte/config/weather_source.yaml
+++ b/airbyte/config/weather_source.yaml
@@ -1,0 +1,11 @@
+source:
+  name: weather_data
+  connector: http
+  configuration:
+    base_url: https://api.weather.example.com
+    api_key: ${WEATHER_API_KEY}
+    start_date: "2023-01-01T00:00:00Z"
+    location: YOUR_CITY
+  incremental_sync:
+    cursor_field: observation_time
+    replication_method: incremental


### PR DESCRIPTION
## Summary
- add Airbyte source templates for pedestrian, weather, and event data
- add Snowflake destination template with incremental sync
- document deploying configs via Docker Compose

## Testing
- `pre-commit run --files README.md airbyte/config/pedestrian_source.yaml airbyte/config/weather_source.yaml airbyte/config/event_source.yaml airbyte/config/snowflake_destination.yaml` *(fails: `.pre-commit-config.yaml` is not a file)*
- `pytest`