### PR TITLE
Add CI and rollout workflows with secrets documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install dvc[boto3] bentoml flake8 pytest
+
+      - name: Lint
+        run: flake8 .
+
+      - name: Unit tests
+        run: pytest
+
+      - name: DVC checks
+        run: |
+          dvc doctor
+          dvc status || true
+
+      - name: Login to registry
+        if: github.event_name == 'push'
+        run: echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login ${{ vars.REGISTRY }} -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin
+
+      - name: Build Bento image
+        run: |
+          bentoml build .
+          bentoml containerize . -t $IMAGE
+
+      - name: Push image
+        if: github.event_name == 'push'
+        run: docker push $IMAGE

--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -1,0 +1,37 @@
+name: Rollout
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:${{ github.sha }}
+      ROLLOUT_NAME: ${{ vars.ROLLOUT_NAME }}
+      NAMESPACE: ${{ vars.ROLLOUT_NAMESPACE }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: azure/setup-kubectl@v3
+
+      - name: Install Argo Rollouts kubectl plugin
+        run: |
+          curl -L https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64.tar.gz -o kubectl-argo-rollouts.tgz
+          tar -zxvf kubectl-argo-rollouts.tgz
+          sudo mv kubectl-argo-rollouts /usr/local/bin/
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 --decode > $HOME/.kube/config
+
+      - name: Update rollout manifest
+        run: |
+          sed -i "s@image:.*@image: $IMAGE@" argo-rollout.yaml
+
+      - name: Apply rollout
+        run: kubectl apply -f argo-rollout.yaml -n $NAMESPACE
+
+      - name: Promote rollout
+        run: kubectl argo rollouts promote $ROLLOUT_NAME -n $NAMESPACE

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # CityScale-AI-Real-Time-CBD-Foot-Traffic-Forecasting-MLOps-Platform
+
+## Repository Settings
+
+### Secrets
+
+- `REGISTRY_USERNAME` – Container registry username used to push Bento images.
+- `REGISTRY_PASSWORD` – Password or token for the registry user.
+- `KUBE_CONFIG` – Base64 encoded kubeconfig for the target Kubernetes cluster.
+
+### Variables
+
+- `REGISTRY` – Registry host, e.g. `ghcr.io/your-org`.
+- `IMAGE_NAME` – Name of the Bento image repository.
+- `ROLLOUT_NAME` – Name of the Argo Rollout resource to update.
+- `ROLLOUT_NAMESPACE` – Kubernetes namespace where the rollout lives.


### PR DESCRIPTION
## Summary
- add CI workflow to lint, test, check DVC, and build Bento images
- add rollout workflow to patch Argo manifests and promote deployment
- document required repository secrets and variables

## Testing
- `pytest`

