### PR TITLE
Add infrastructure scaffolding for Terraform and Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # CityScale-AI-Real-Time-CBD-Foot-Traffic-Forecasting-MLOps-Platform
+
+## Infrastructure
+
+### Terraform
+Infrastructure as code is organized under `infra/terraform`. Copy the example variables file and adjust values for your environment:
+
+```bash
+cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars
+terraform -chdir=infra/terraform/core init
+terraform -chdir=infra/terraform/core apply
+```
+
+### Helmfile
+Helmfile manifests for Ray, Prometheus, and Grafana live in `infra/helmfile`. Deploy the charts with:
+
+```bash
+cd infra/helmfile
+helmfile sync
+```

--- a/infra/helmfile/helmfile.yaml
+++ b/infra/helmfile/helmfile.yaml
@@ -1,0 +1,26 @@
+repositories:
+  - name: kuberay
+    url: https://ray-project.github.io/kuberay-helm/
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+  - name: grafana
+    url: https://grafana.github.io/helm-charts
+
+releases:
+  - name: ray-cluster
+    namespace: ray
+    chart: kuberay/kuberay
+    values:
+      - ray.yaml
+
+  - name: prometheus
+    namespace: monitoring
+    chart: prometheus-community/prometheus
+    values:
+      - monitoring.yaml
+
+  - name: grafana
+    namespace: monitoring
+    chart: grafana/grafana
+    values:
+      - monitoring.yaml

--- a/infra/helmfile/monitoring.yaml
+++ b/infra/helmfile/monitoring.yaml
@@ -1,0 +1,8 @@
+prometheus:
+  service:
+    type: ClusterIP
+
+grafana:
+  adminPassword: admin
+  service:
+    type: ClusterIP

--- a/infra/helmfile/ray.yaml
+++ b/infra/helmfile/ray.yaml
@@ -1,0 +1,9 @@
+image:
+  tag: latest
+head:
+  resources:
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+worker:
+  replicas: 1

--- a/infra/terraform/core/.terraform.lock.hcl
+++ b/infra/terraform/core/.terraform.lock.hcl
@@ -1,0 +1,105 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.7.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:MR1e3FM/ZMHBaUOsLJu2XIjkbogmh5q5IV/N73zGX14=",
+    "zh:3c0a256f813e5e2c1e1aa137204ad9168ebe487f6cee874af9e9c78eb300568e",
+    "zh:3c49dd75ea28395b29ba259988826b956c8adf6c0b59dd8874feb4f47bad976a",
+    "zh:3e6e3e3bfc6594f4f9e2c017ee588c5fcad394b87dd0b68a3f37cd66001f3c8c",
+    "zh:3f9b55826eeebf9b2ed448fc111d772c703e1edc6678e1bb646e66f3c3f9308f",
+    "zh:44e4ced936045ddc42d22c653a6427e7eb2b7aee918dff8438da0cb40996beb4",
+    "zh:474ab4d63918f41e8ea1cef43aeb1c719629dbf289db175c95de1431a8853ae7",
+    "zh:71b9e1d82c5ccc8d9bf72b3712c2b90722fc1f35a0f0f7a9557b9ee01971e6e2",
+    "zh:7723256d6ccc55f4000d1df8db202b02b30a7d917f5d31624c717e14ba15ea95",
+    "zh:82174836faa830aff0e47ea61d4cfbb5c97e1e944b1978f1d933acd37f584c88",
+    "zh:8e62fdc10206ba7232eec991e5a387378f2fbe47cc717b7f60eeb1df2c974514",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:be24dd2d53b224d7098e75ca432746e3420ce071189eea100aa8cbcd2498d389",
+    "zh:d27651d0e458933127ddca35a833e1a0f0ff0c131391288b3239763a2fd8f96f",
+    "zh:d33c181fff1b96bf8366e6c3d92408370b21649291e8f4d1f7e9a3fbb920fc9d",
+    "zh:edc0a0a84f85036c6d3df29d09557bd43206d9ee57b10542b484050f0f34d242",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.7"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
+    "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
+    "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
+    "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
+    "zh:2b9269d91b742a71b2248439d5e9824f0447e6d261bfb86a8a88528609b136d1",
+    "zh:3d8ae039af21426072c66d6a59a467d51f2d9189b8198616888c1b7fc42addc7",
+    "zh:3ef4e2db5bcf3e2d915921adced43929214e0946a6fb11793085d9a48995ae01",
+    "zh:42ae54381147437c83cbb8790cc68935d71b6357728a154109d3220b1beb4dc9",
+    "zh:4496b362605ae4cbc9ef7995d102351e2fe311897586ffc7a4a262ccca0c782a",
+    "zh:652a2401257a12706d32842f66dac05a735693abcb3e6517d6b5e2573729ba13",
+    "zh:7406c30806f5979eaed5f50c548eced2ea18ea121e01801d2f0d4d87a04f6a14",
+    "zh:7848429fd5a5bcf35f6fee8487df0fb64b09ec071330f3ff240c0343fe2a5224",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:Ka8mEwRFXBabR33iN/WTIEW6RP0z13vFsDlwn11Pf2I=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/infra/terraform/core/main.tf
+++ b/infra/terraform/core/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+  name   = var.vpc_name
+  cidr   = var.vpc_cidr
+
+  azs             = var.availability_zones
+  public_subnets  = var.public_subnets
+  private_subnets = var.private_subnets
+}
+
+module "eks" {
+  source = "terraform-aws-modules/eks/aws"
+  # Additional EKS configuration will be added here
+}

--- a/infra/terraform/core/variables.tf
+++ b/infra/terraform/core/variables.tf
@@ -1,0 +1,39 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "List of private subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "EKS Kubernetes version"
+  type        = string
+}

--- a/infra/terraform/data/.terraform.lock.hcl
+++ b/infra/terraform/data/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.7.0"
+  hashes = [
+    "h1:MR1e3FM/ZMHBaUOsLJu2XIjkbogmh5q5IV/N73zGX14=",
+    "zh:3c0a256f813e5e2c1e1aa137204ad9168ebe487f6cee874af9e9c78eb300568e",
+    "zh:3c49dd75ea28395b29ba259988826b956c8adf6c0b59dd8874feb4f47bad976a",
+    "zh:3e6e3e3bfc6594f4f9e2c017ee588c5fcad394b87dd0b68a3f37cd66001f3c8c",
+    "zh:3f9b55826eeebf9b2ed448fc111d772c703e1edc6678e1bb646e66f3c3f9308f",
+    "zh:44e4ced936045ddc42d22c653a6427e7eb2b7aee918dff8438da0cb40996beb4",
+    "zh:474ab4d63918f41e8ea1cef43aeb1c719629dbf289db175c95de1431a8853ae7",
+    "zh:71b9e1d82c5ccc8d9bf72b3712c2b90722fc1f35a0f0f7a9557b9ee01971e6e2",
+    "zh:7723256d6ccc55f4000d1df8db202b02b30a7d917f5d31624c717e14ba15ea95",
+    "zh:82174836faa830aff0e47ea61d4cfbb5c97e1e944b1978f1d933acd37f584c88",
+    "zh:8e62fdc10206ba7232eec991e5a387378f2fbe47cc717b7f60eeb1df2c974514",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:be24dd2d53b224d7098e75ca432746e3420ce071189eea100aa8cbcd2498d389",
+    "zh:d27651d0e458933127ddca35a833e1a0f0ff0c131391288b3239763a2fd8f96f",
+    "zh:d33c181fff1b96bf8366e6c3d92408370b21649291e8f4d1f7e9a3fbb920fc9d",
+    "zh:edc0a0a84f85036c6d3df29d09557bd43206d9ee57b10542b484050f0f34d242",
+  ]
+}
+
+provider "registry.terraform.io/snowflakedb/snowflake" {
+  version = "2.4.0"
+  hashes = [
+    "h1:GUohzwTLd4ovM5V+ITuzIbt1c0bsbtNFrc2At/+lU90=",
+    "zh:176db8fa73f52495f7e5b26c67a5d03c7fc16a83ae8c177bc2d06bcc560bca68",
+    "zh:23b4833f20ce23f883ca6dcc34d340c765e5910a3ea517fa20f0c1c833ca1df7",
+    "zh:278fc7ca6f41dbb202659b26c878238d503992b834f05dac64cbdde08a70d568",
+    "zh:62d4f7dc8cc04c882920aa7415299a179b7718e577f900132c2e456f39f166d5",
+    "zh:740d70c0782e7de084340b64cf6114423b3739d2de797acf27c1e3601e869744",
+    "zh:94615e4e6ffa4d8631571aaa499784916bed69aa4637425f144c4faa57ef00b6",
+    "zh:9471e4808bbc33a3703b98d2d06eccb450d898f5416bb709c72ae9a90436cee6",
+    "zh:99c5ebb855af79cbb8a91128e1f6a1c9347b96c011061a76bb3abf85517f8444",
+    "zh:ad0327bf3f7843b6776c495953163d31956812b5cec0c3a38fb84833ebace193",
+    "zh:de03a586a2b4f4bf04c89eebe8d9012ba8a5fecea59853215edc5cb554a69fe1",
+    "zh:e325156d09c495cf66f3b7d0326a9b06f22213e7a4b58576111afaa5480eab46",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/terraform/data/main.tf
+++ b/infra/terraform/data/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    snowflake = {
+      source = "snowflakedb/snowflake"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "snowflake" {}
+
+resource "aws_s3_bucket" "data_bucket" {
+  bucket = var.data_bucket_name
+}
+
+# Placeholder for Snowflake role
+# resource "snowflake_role" "data_engineer" {
+#   name = var.snowflake_role_name
+# }

--- a/infra/terraform/data/variables.tf
+++ b/infra/terraform/data/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "data_bucket_name" {
+  description = "Name of the S3 bucket for data"
+  type        = string
+}
+
+variable "snowflake_account" {
+  description = "Snowflake account identifier"
+  type        = string
+}
+
+variable "snowflake_user" {
+  description = "Snowflake user name"
+  type        = string
+}
+
+variable "snowflake_password" {
+  description = "Snowflake user password"
+  type        = string
+}
+
+variable "snowflake_role_name" {
+  description = "Name of the Snowflake role"
+  type        = string
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,14 @@
+aws_region         = "us-east-1"
+vpc_name           = "example-vpc"
+vpc_cidr           = "10.0.0.0/16"
+availability_zones = ["us-east-1a", "us-east-1b"]
+public_subnets     = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnets    = ["10.0.3.0/24", "10.0.4.0/24"]
+cluster_name       = "example-eks"
+cluster_version    = "1.29"
+
+data_bucket_name   = "example-data-bucket"
+snowflake_account  = "abc12345"
+snowflake_user     = "user"
+snowflake_password = "password"
+snowflake_role_name = "DATA_ENGINEER"


### PR DESCRIPTION
## Summary
- scaffold Terraform core module for VPC/EKS and data module for Snowflake roles/S3 buckets
- add Helmfile definitions for Ray, Prometheus, and Grafana
- document Terraform and Helmfile usage

## Testing
- `terraform -chdir=infra/terraform/core init -backend=false`
- `terraform -chdir=infra/terraform/core validate`
- `terraform -chdir=infra/terraform/data init -backend=false`
- `terraform -chdir=infra/terraform/data validate`
- `helmfile lint` *(fails: chart "kuberay" not found)*
