### PR TITLE
Add Tecton feature definitions and materialization script

### DIFF
--- a/features/tecton/features.py
+++ b/features/tecton/features.py
@@ -1,0 +1,153 @@
+"""Tecton feature definitions for the foot traffic forecasting project."""
+
+from datetime import timedelta
+
+try:
+    from tecton import (
+        Aggregation,
+        Entity,
+        Field,
+        FileConfig,
+        batch_feature_view,
+        batch_source,
+    )
+except Exception:  # pragma: no cover - Tecton may not be installed
+    Aggregation = Entity = Field = FileConfig = batch_feature_view = batch_source = None  # type: ignore
+
+# Entities
+cbd = Entity(name="cbd", join_keys=["cbd_id"], description="Central business district identifier")  # type: ignore
+
+# Data sources ---------------------------------------------------------------------------
+# These sources are placeholders and should be updated with real data connectors.
+foot_traffic_source = batch_source(  # type: ignore
+    name="foot_traffic_source",
+    batch_config=FileConfig(
+        uri="s3://placeholder/foot_traffic/*.parquet",
+        file_format="parquet",
+    ),
+    timestamp_field="timestamp",
+)
+
+weather_source = batch_source(  # type: ignore
+    name="weather_source",
+    batch_config=FileConfig(
+        uri="s3://placeholder/weather/*.parquet",
+        file_format="parquet",
+    ),
+    timestamp_field="timestamp",
+)
+
+events_source = batch_source(  # type: ignore
+    name="events_source",
+    batch_config=FileConfig(
+        uri="s3://placeholder/events/*.parquet",
+        file_format="parquet",
+    ),
+    timestamp_field="event_time",
+)
+
+holidays_source = batch_source(  # type: ignore
+    name="holidays_source",
+    batch_config=FileConfig(
+        uri="s3://placeholder/holidays/*.parquet",
+        file_format="parquet",
+    ),
+    timestamp_field="date",
+)
+
+# Feature views -------------------------------------------------------------------------
+
+@batch_feature_view(  # type: ignore
+    sources=[foot_traffic_source],
+    entities=[cbd],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    ttl=timedelta(days=7),
+    features=[
+        Field(name="rolling_1h_count", dtype="int64"),
+        Field(name="rolling_24h_count", dtype="int64"),
+    ],
+    aggregations=[
+        Aggregation(
+            column="count",
+            function="sum",
+            time_window=timedelta(hours=1),
+            sliding_window=timedelta(hours=1),
+            name="rolling_1h_count",
+        ),
+        Aggregation(
+            column="count",
+            function="sum",
+            time_window=timedelta(hours=24),
+            sliding_window=timedelta(hours=1),
+            name="rolling_24h_count",
+        ),
+    ],
+)
+def foot_traffic_rolling_counts(foot_traffic):
+    """Rolling 1h and 24h counts of foot traffic events."""
+    return foot_traffic
+
+
+@batch_feature_view(  # type: ignore
+    sources=[weather_source],
+    entities=[cbd],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    ttl=timedelta(days=7),
+    features=[Field(name="temp_lag_1h", dtype="float64")],
+)
+def weather_lag(weather):
+    """One hour lag of temperature readings."""
+    return f"""
+        SELECT
+            cbd_id,
+            timestamp,
+            LAG(temperature, 1) OVER (PARTITION BY cbd_id ORDER BY timestamp) AS temp_lag_1h
+        FROM {weather}
+    """
+
+
+@batch_feature_view(  # type: ignore
+    sources=[events_source],
+    entities=[cbd],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    ttl=timedelta(days=30),
+    features=[Field(name="event_attendance", dtype="int64")],
+    aggregations=[
+        Aggregation(
+            column="attendance",
+            function="sum",
+            time_window=timedelta(days=1),
+            sliding_window=timedelta(days=1),
+            name="event_attendance",
+        )
+    ],
+)
+def event_attendance(events):
+    """Aggregate attendance for events in the previous day."""
+    return events
+
+
+@batch_feature_view(  # type: ignore
+    sources=[holidays_source],
+    entities=[cbd],
+    mode="spark_sql",
+    online=True,
+    offline=True,
+    ttl=timedelta(days=365),
+    features=[Field(name="is_holiday", dtype="bool")],
+)
+def holiday_flag(holidays):
+    """Boolean flag indicating whether the date is a public holiday."""
+    return f"""
+        SELECT
+            cbd_id,
+            date AS timestamp,
+            TRUE AS is_holiday
+        FROM {holidays}
+    """

--- a/features/tecton/repo.py
+++ b/features/tecton/repo.py
@@ -1,0 +1,43 @@
+"""Utilities for initializing the Tecton client."""
+
+import os
+from typing import Optional
+
+try:
+    from tecton import TectonClient
+except Exception:  # pragma: no cover - tecton may not be installed in CI
+    TectonClient = None  # type: ignore
+
+
+def get_tecton_client(url: Optional[str] = None, api_key: Optional[str] = None) -> "TectonClient":
+    """Return an initialized :class:`TectonClient` instance.
+
+    Parameters
+    ----------
+    url:
+        Optional Tecton workspace URL. Defaults to the ``TECTON_URL`` environment variable.
+    api_key:
+        Optional Tecton API key. Defaults to the ``TECTON_API_KEY`` environment variable.
+
+    Returns
+    -------
+    TectonClient
+        An initialized Tecton client.
+
+    Notes
+    -----
+    This helper defers importing and instantiating the Tecton client until runtime so that
+    importing this module does not require the Tecton dependency to be installed. This makes
+    unit testing and static analysis of the repository possible without access to Tecton.
+    """
+
+    if TectonClient is None:  # pragma: no cover - handled by try/except above
+        raise RuntimeError("Tecton SDK is not installed. Install tecton-sdk to use this helper.")
+
+    url = url or os.environ.get("TECTON_URL")
+    api_key = api_key or os.environ.get("TECTON_API_KEY")
+
+    if not url or not api_key:
+        raise ValueError("TECTON_URL and TECTON_API_KEY must be set to initialize the client")
+
+    return TectonClient(url, api_key)

--- a/scripts/register_and_materialize.sh
+++ b/scripts/register_and_materialize.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Register all Tecton objects defined in the repo and materialize their data.
+#
+# Usage:
+#   scripts/register_and_materialize.sh START_TIME END_TIME
+#
+# The start and end times should be provided in ISO-8601 format, e.g.
+#   scripts/register_and_materialize.sh 2024-01-01T00:00:00Z 2024-01-02T00:00:00Z
+#
+# This script requires the Tecton CLI to be installed and configured with
+# appropriate credentials (see https://docs.tecton.ai). It should be run from
+# the root of the repository.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 START_TIME END_TIME" >&2
+  exit 1
+fi
+
+START=$1
+END=$2
+
+# Register (apply) feature definitions in the current repository.
+tecton apply
+
+# Materialize each feature view.
+tecton materialize feature-view foot_traffic_rolling_counts --start-time "$START" --end-time "$END"
+tecton materialize feature-view weather_lag --start-time "$START" --end-time "$END"
+tecton materialize feature-view event_attendance --start-time "$START" --end-time "$END"
+tecton materialize feature-view holiday_flag --start-time "$START" --end-time "$END"


### PR DESCRIPTION
## Summary
- initialize Tecton client with helper
- define rolling count, weather lag, event attendance and holiday features
- add script to register and materialize features

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f967f43f083298fe189e8bfb1aba4