### PR TITLE
Add BentoML service and container build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # CityScale-AI-Real-Time-CBD-Foot-Traffic-Forecasting-MLOps-Platform
+
+## Bento Service
+
+A BentoML service for foot traffic forecasting is defined in `models/serving/service.py` and configured via `bentofile.yaml`.
+
+### Build the Bento bundle
+
+```bash
+bentoml build
+```
+
+### Build the container image
+
+```bash
+bentoml containerize foot_traffic_service:latest
+```

--- a/bentofile.yaml
+++ b/bentofile.yaml
@@ -1,0 +1,9 @@
+service: models.serving.service:svc
+labels:
+  owner: ml-team
+  project: foot-traffic
+python:
+  packages:
+    - bentoml>=1.1.6
+    - scikit-learn
+    - pydantic

--- a/models/serving/service.py
+++ b/models/serving/service.py
@@ -1,0 +1,22 @@
+import bentoml
+from bentoml.io import JSON
+from pydantic import BaseModel
+
+
+class TrafficRequest(BaseModel):
+    """Input data schema for foot traffic forecasting."""
+    features: list[float]
+
+
+# Load the latest trained model registered in BentoML's model store.
+model_runner = bentoml.sklearn.get("foot_traffic:latest").to_runner()
+
+# Define the BentoML service with a /predict endpoint.
+svc = bentoml.Service("foot_traffic_service", runners=[model_runner])
+
+
+@svc.api(input=JSON(pydantic_model=TrafficRequest), output=JSON())
+def predict(req: TrafficRequest) -> dict:
+    """Return foot traffic predictions for the provided features."""
+    prediction = model_runner.run(req.features)
+    return {"prediction": prediction}


### PR DESCRIPTION
## Summary
- add BentoML service exposing `/predict` endpoint backed by stored foot traffic model
- declare Bento build settings and dependencies
- document building the Bento bundle and container image

## Testing
- `python -m py_compile models/serving/service.py`