### PR TITLE
Add Ray cluster and Argo Rollout manifests

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,20 @@
+---
+name: Deployment
+
+'on':
+  push:
+    branches: [main]
+  pull_request: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: v1.26.0
+      - name: Validate Kubernetes manifests
+        run: |
+          kubectl apply --dry-run=client -f k8s/ray-cluster.yaml
+          kubectl apply --dry-run=client -f k8s/argo-rollout.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # CityScale-AI-Real-Time-CBD-Foot-Traffic-Forecasting-MLOps-Platform
+
+## Deployment
+
+Refer to [docs/deployment.md](docs/deployment.md) for Kubernetes deployment instructions, including Ray cluster and Argo Rollouts manifests.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,23 @@
+# Deployment Guide
+
+This project ships Kubernetes manifests to simplify deployment.
+
+## Ray Cluster
+
+The Ray cluster is defined in [`k8s/ray-cluster.yaml`](../k8s/ray-cluster.yaml). It includes a single head node and an autoscaling worker group (1–5 replicas).
+
+Apply the manifest:
+
+```bash
+kubectl apply -f k8s/ray-cluster.yaml
+```
+
+## Canary Rollout
+
+Application updates are managed via Argo Rollouts using [`k8s/argo-rollout.yaml`](../k8s/argo-rollout.yaml). The rollout advances traffic in canary steps of 5%, 25%, and 100%.
+
+Apply the manifest:
+
+```bash
+kubectl apply -f k8s/argo-rollout.yaml
+```

--- a/k8s/argo-rollout.yaml
+++ b/k8s/argo-rollout.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: example-rollout
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+        - name: example
+          image: nginx:1.25
+          ports:
+            - containerPort: 80
+  strategy:
+    canary:
+      steps:
+        - setWeight: 5
+        - pause: {duration: 30}
+        - setWeight: 25
+        - pause: {duration: 30}
+        - setWeight: 100

--- a/k8s/ray-cluster.yaml
+++ b/k8s/ray-cluster.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: ray-cluster
+spec:
+  headGroupSpec:
+    serviceType: ClusterIP
+    replicas: 1
+    rayStartParams:
+      dashboard-host: "0.0.0.0"
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:latest
+            resources:
+              requests:
+                cpu: "500m"
+                memory: "512Mi"
+  workerGroupSpecs:
+    - groupName: worker-group
+      replicas: 1
+      minReplicas: 1
+      maxReplicas: 5
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:latest
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: "512Mi"


### PR DESCRIPTION
## Summary
- add RayCluster manifest with autoscaling worker nodes
- add Argo Rollout manifest implementing 5%→25%→100% canary strategy
- document deployment and validate manifests in CI

## Testing
- `yamllint k8s .github/workflows`


------
https://chatgpt.com/codex/tasks/task_e_688f96822d6c8329bbe174ea39d80859