### PR TITLE
Add BentoML model saving and PyTorch serving

### DIFF
--- a/bentofile.yaml
+++ b/bentofile.yaml
@@ -2,8 +2,10 @@ service: models.serving.service:svc
 labels:
   owner: ml-team
   project: foot-traffic
+models:
+  - foot_traffic:latest
 python:
   packages:
     - bentoml>=1.1.6
-    - scikit-learn
+    - torch
     - pydantic

--- a/models/serving/service.py
+++ b/models/serving/service.py
@@ -1,4 +1,5 @@
 import bentoml
+import torch
 from bentoml.io import JSON
 from pydantic import BaseModel
 
@@ -8,8 +9,8 @@ class TrafficRequest(BaseModel):
     features: list[float]
 
 
-# Load the latest trained model registered in BentoML's model store.
-model_runner = bentoml.sklearn.get("foot_traffic:latest").to_runner()
+# Load the latest trained PyTorch model registered in BentoML's model store.
+model_runner = bentoml.pytorch.get("foot_traffic:latest").to_runner()
 
 # Define the BentoML service with a /predict endpoint.
 svc = bentoml.Service("foot_traffic_service", runners=[model_runner])
@@ -18,5 +19,6 @@ svc = bentoml.Service("foot_traffic_service", runners=[model_runner])
 @svc.api(input=JSON(pydantic_model=TrafficRequest), output=JSON())
 def predict(req: TrafficRequest) -> dict:
     """Return foot traffic predictions for the provided features."""
-    prediction = model_runner.run(req.features)
-    return {"prediction": prediction}
+    tensor = torch.tensor(req.features, dtype=torch.float32).unsqueeze(0)
+    prediction = model_runner.run(tensor)
+    return {"prediction": float(prediction.squeeze().item())}

--- a/train.py
+++ b/train.py
@@ -69,6 +69,28 @@ def main() -> None:
     print("Best parameters:", best.params)
     print("Best value:", best.value)
 
+    # Train a final model using the best hyperparameters and save with BentoML
+    import bentoml
+
+    datamodule = FootTrafficDataModule(
+        train_path=args.train_path,
+        val_path=args.val_path,
+        test_path=args.test_path,
+        batch_size=args.batch_size,
+    )
+
+    final_model = FootTrafficModel(
+        hidden_dim=best.params["hidden_dim"],
+        lr=best.params["lr"],
+    )
+
+    trainer = pl.Trainer(max_epochs=args.max_epochs, enable_checkpointing=False)
+    trainer.fit(final_model, datamodule=datamodule)
+
+    # Save the trained PyTorch model to BentoML's model store
+    final_model.model.eval()
+    bentoml.pytorch.save_model("foot_traffic", final_model.model)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Save the trained PyTorch model with BentoML after hyperparameter tuning
- Serve BentoML-registered model with a PyTorch runner and tensor input
- Bundle saved model and torch dependency in BentoML build config

## Testing
- `pytest -q`

