### PR TITLE
Add basic offline tests for core components

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -1,0 +1,22 @@
+import torch
+import pytest
+
+from models.lightning.datamodule import FootTrafficDataModule
+
+
+def create_dataset(path, num_samples=10, num_features=4):
+    x = torch.randn(num_samples, num_features)
+    y = torch.randn(num_samples, 1)
+    torch.save((x, y), path)
+
+
+def test_train_dataloader(tmp_path):
+    data_path = tmp_path / "train.pt"
+    create_dataset(data_path)
+    dm = FootTrafficDataModule(str(data_path), batch_size=2)
+    dm.setup('fit')
+    loader = dm.train_dataloader()
+    batch = next(iter(loader))
+    features, targets = batch
+    assert features.shape[0] == 2
+    assert targets.shape[0] == 2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,18 @@
+import torch
+
+from models.lightning.model import FootTrafficModel
+
+
+def test_forward_output_shape():
+    model = FootTrafficModel(input_dim=4, hidden_dim=8)
+    x = torch.randn(3, 4)
+    y = model(x)
+    assert y.shape == (3, 1)
+
+
+def test_training_step_returns_loss():
+    model = FootTrafficModel(input_dim=4, hidden_dim=8)
+    x = torch.randn(3, 4)
+    y = torch.randn(3, 1)
+    loss = model.training_step((x, y), 0)
+    assert loss.dim() == 0  # scalar tensor

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,28 @@
+import sys
+import types
+
+
+def test_predict_logs_and_returns_sum(monkeypatch):
+    logs = []
+
+    class DummyLogger:
+        def session(self):
+            class Session:
+                def __enter__(self_inner):
+                    return self_inner
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+                def log(self_inner, data):
+                    logs.append(data)
+            return Session()
+
+    dummy_why = types.SimpleNamespace(logger=lambda **kwargs: DummyLogger())
+    monkeypatch.setitem(sys.modules, 'whylogs', dummy_why)
+
+    import importlib
+    serve = importlib.import_module('serving.serve')
+
+    result = serve.predict([1, 2, 3])
+    assert result == 6
+    assert logs[0]['prediction'] == 6
+    assert logs[0]['features'] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- add tests for Lightning data module, model, and service endpoint
- ensure tests run offline with dummy WhyLogs logger
- include conftest to expose repo root for imports

## Testing
- `pytest`
