### PR TITLE
Move local dev script and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,18 @@ cp .env.sample .env  # add Snowflake creds & W&B API key
 # 2. Start Airbyte (compose)
 docker compose -f airbyte/docker-compose.yaml up -d
 
-# 3. Run Dagster dev server
+# 3. Populate required environment variables
+# export SNOWFLAKE_ACCOUNT=<account>
+# export SNOWFLAKE_USER=<user>
+# export SNOWFLAKE_PASSWORD=<password>
+# export WANDB_API_KEY=<api-key>
+# export WHYLABS_API_KEY=<api-key>
+
+# 4. Run Dagster dev server
 export DAGSTER_HOME=$PWD/dagster_home
 dagster dev -f dags/jobs/local_dev.py &
 
-# 4. Trigger sample ETL + training
+# 5. Trigger sample ETL + training
 python dags/jobs/run_local.py --sample
 ```
 

--- a/dags/jobs/local_dev.py
+++ b/dags/jobs/local_dev.py
@@ -1,4 +1,4 @@
 """Entry point for running Dagster's development server."""
 
-from dags.jobs.pipelines import defs
+from .pipelines import defs
 


### PR DESCRIPTION
## Summary
- move Dagster development script into `dags/jobs`
- list environment variables needed before starting Dagster dev server

## Testing
- `python -m py_compile dags/jobs/local_dev.py`
- `pytest`