### PR TITLE
Add architecture diagram and demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Event Feed CSV ──┘                                   │
      WhyLabs drift + Prometheus latency ───► Slack #cityscale‑alerts
 ```
 
+The diagram above is maintained in [docs/architecture.drawio](docs/architecture.drawio).
+To export it to PNG for slides or docs:
+
+```bash
+npx @drawio/cli docs/architecture.drawio -o docs/architecture.png
+```
+
 ---
 
 ## Key Competencies & Their Implementation
@@ -262,6 +269,10 @@ helmfile -f infra/helmfile/ray.yaml apply
 | Rollout         | 3:00‑4:00 | Argo Rollouts UI + Kiali |
 | Autoscale       | 4:00‑5:00 | kubectl top pod          |
 | Outro           | 5:00‑6:00 | Cost slide & repo link   |
+
+A step‑by‑step narration lives in [docs/demo_script.md](docs/demo_script.md).
+Start the local stack as described in [Local Development Environment](#local-development-environment)
+and follow the script while recording.
 
 Record 1440p\@60 fps; OBS profile saved to `docs/obs/cityscale.json`.
 

--- a/docs/architecture.drawio
+++ b/docs/architecture.drawio
@@ -1,0 +1,55 @@
+<mxfile host="app.diagrams.net">
+  <diagram id="cityscale-arch" name="Architecture">
+    <mxGraphModel dx="991" dy="559" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="800">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="Data Sources" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="20" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="3" value="Airbyte" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="180" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="4" value="Snowflake" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="340" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="5" value="Dagster ETL" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="500" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="6" value="Feature Store" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="660" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="7" value="Training &amp; Tuning" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="820" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="8" value="Serving" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="980" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="9" value="Monitoring" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="1140" y="40" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="2" target="3">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="3" target="4">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="12" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="4" target="5">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="5" target="6">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="14" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="6" target="7">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="7" target="8">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="8" target="9">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/demo_script.md
+++ b/docs/demo_script.md
@@ -1,0 +1,21 @@
+# CityScale AI Demo Script
+
+This script walks through a six‑minute demo of the platform. Follow it while recording as outlined in the README.
+
+## Prerequisites
+
+- Local stack running (Airbyte, Dagster dev server, and Grafana) as per [Local Development Environment](../README.md#local-development-environment).
+- OBS configured with the profile in `docs/obs/cityscale.json`.
+
+## Steps
+
+1. **Intro (0:00‑0:30)** – Introduce CityScale AI and what the demo will show.
+2. **Live heat‑map (0:30‑1:00)** – Share the Grafana panel that visualises current pedestrian counts.
+3. **Inject festival (1:00‑1:45)** – Insert a mock event via Dagster and show the WhyLabs drift alert in Slack.
+4. **Dagster retrain (1:45‑2:30)** – Trigger `python dags/jobs/run_local.py --sample` and browse the Dagster UI as the job runs.
+5. **W&B sweep (2:30‑3:00)** – Open the latest Weights & Biases sweep and highlight top metrics.
+6. **Rollout (3:00‑4:00)** – Use the Argo Rollouts UI to show a canary progressing from 5 % to 100 %.
+7. **Autoscale (4:00‑5:00)** – Run `kubectl top pod` to show Ray Serve scaling.
+8. **Outro (5:00‑6:00)** – Wrap up with the monthly cost slide and link to the repository.
+
+Record at 1440p@60 fps. Adjust timing as needed to stay within six minutes.


### PR DESCRIPTION
## Summary
- add Draw.io architecture diagram and demo script docs
- reference diagram and demo script from README
- document how to export the architecture diagram and rehearse the demo

## Testing
- `pytest`