### PR TITLE
chore: update pedestrian data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npx @drawio/cli docs/architecture.drawio -o docs/architecture.png
 
 | Feed                                                  | Frequency         | Access         | Notes                           |
 | ----------------------------------------------------- | ----------------- | -------------- | ------------------------------- |
-| Sydney Pedestrian Counters (City of Sydney Open Data) | Every 15 min JSON | Public API key | \~60 counters                   |
+| Sydney Pedestrian Counters (City of Sydney Open Data) | Hourly JSON        | API token (`PEDESTRIAN_API_TOKEN`) | \~60 counters                   |
 | BOM Weather API (Observations + Forecast)             | Hourly REST       | Public         | Temp, rain, wind                |
 | Ticketek / Eventbrite scraping (CBD events)           | Nightly CSV       | Scraper + cron | Event type, expected attendance |
 | NSW Public Holidays                                   | Annual CSV        | Static         | Used for holiday flag feature   |
@@ -168,6 +168,7 @@ docker compose -f airbyte/docker-compose.yaml up -d
 # export SNOWFLAKE_ACCOUNT=<account>
 # export SNOWFLAKE_USER=<user>
 # export SNOWFLAKE_PASSWORD=<password>
+# export PEDESTRIAN_API_TOKEN=<token>
 # export WANDB_API_KEY=<api-key>
 # export WHYLABS_API_KEY=<api-key>
 

--- a/airbyte/config/pedestrian_source.yaml
+++ b/airbyte/config/pedestrian_source.yaml
@@ -2,9 +2,9 @@ source:
   name: pedestrian_counts
   connector: http
   configuration:
-    base_url: https://data.melbourne.vic.gov.au/resource/b2ak-trbp.json
+    base_url: https://services1.arcgis.com/cNVyNtjGVZybOQWZ/arcgis/rest/services/Automatic_Hourly_Pedestrian_Count/FeatureServer/0/query?where=1%3D1&outFields=*&f=json
     app_token: ${PEDESTRIAN_API_TOKEN}
     start_date: "2023-01-01T00:00:00Z"
   incremental_sync:
-    cursor_field: date_time
+    cursor_field: Date
     replication_method: incremental


### PR DESCRIPTION
## Summary
- use City of Sydney Open Data API for pedestrian counts
- document PEDESTRIAN_API_TOKEN in README

## Testing
- `pytest`
