### PR TITLE
Configure Argo rollout for Bento service

### DIFF
--- a/.github/workflows/rollout.yml
+++ b/.github/workflows/rollout.yml
@@ -26,12 +26,11 @@ jobs:
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBE_CONFIG }}" | base64 --decode > $HOME/.kube/config
 
-      - name: Update rollout manifest
-        run: |
-          sed -i "s@image:.*@image: $IMAGE@" k8s/argo-rollout.yaml
+      - name: Render rollout manifest
+        run: envsubst < k8s/argo-rollout.yaml > rendered-rollout.yaml
 
       - name: Apply rollout
-        run: kubectl apply -f k8s/argo-rollout.yaml -n $NAMESPACE
+        run: kubectl apply -f rendered-rollout.yaml -n $NAMESPACE
 
       - name: Promote rollout
         run: kubectl argo rollouts promote $ROLLOUT_NAME -n $NAMESPACE

--- a/k8s/argo-rollout.yaml
+++ b/k8s/argo-rollout.yaml
@@ -2,22 +2,36 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: example-rollout
+  name: foot-traffic-rollout
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: example
+      app: foot-traffic
   template:
     metadata:
       labels:
-        app: example
+        app: foot-traffic
     spec:
       containers:
-        - name: example
-          image: nginx:1.25
+        - name: foot-traffic
+          image: ${IMAGE}
+          env:
+            - name: BENTOML_PORT
+              value: "3000"
           ports:
-            - containerPort: 80
+            - name: http
+              containerPort: 3000
+            - name: metrics
+              containerPort: 3001
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
   strategy:
     canary:
       steps:


### PR DESCRIPTION
## Summary
- align rollout manifest with Bento service image, ports, env vars, and health probes
- render rollout manifest in workflow using CI image path

## Testing
- `flake8 .` *(fails: multiple E501 line too long errors)*
- `pytest`
- `dvc doctor`
- `dvc status || true`